### PR TITLE
変数のハイライトはあったほうが便利なので復活

### DIFF
--- a/init.el
+++ b/init.el
@@ -236,8 +236,7 @@
   :config
   ;; eglotで無効にする機能
   (setq eglot-ignored-server-capabilities
-        '(:documentHighlightProvider ;; カーソル下のシンボルハイライト、無効化すると軽量になる
-          :inlayHintProvider ;; インラインのヒント表示
+        '(:inlayHintProvider ;; インラインのヒント表示
           ))
   )
 


### PR DESCRIPTION
言語サーバーとの通信料削減のためにオフにしていた機能
あまり使ってないかと思ってたがないと不便だった